### PR TITLE
beryllium: Enforce presence of MIUI 8.11.15 vendor and matching firmware

### DIFF
--- a/board-info.txt
+++ b/board-info.txt
@@ -1,0 +1,3 @@
+require version-modem=2018-11-14 19:25:39
+require version-vendor=1542276066,28
+require version-miui=8.11.15


### PR DESCRIPTION
We have modem timestamp, MIUI version, vendor build date, and vndk version

Change-Id: Idcd80d54bbc0cc1e046f9e7123573d661be33bae
Signed-off-by: Akhil Narang <akhilnarang.1999@gmail.com>