### PR TITLE
beryllium: Declare supported LiveDisplay 2.0 interfaces

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -28,6 +28,9 @@ BOARD_HAVE_QCOM_FM := true
 # Kernel
 TARGET_KERNEL_CONFIG := beryllium_defconfig
 
+# HIDL
+DEVICE_FRAMEWORK_MANIFEST_FILE += $(DEVICE_PATH)/framework_manifest.xml
+
 # Partitions
 BOARD_RECOVERYIMAGE_PARTITION_SIZE := 67108864
 

--- a/framework_manifest.xml
+++ b/framework_manifest.xml
@@ -1,0 +1,15 @@
+<manifest version="1.0" type="framework">
+    <hal format="hidl">
+        <name>vendor.lineage.livedisplay</name>
+        <transport>hwbinder</transport>
+        <version>2.0</version>
+        <interface>
+            <name>IDisplayModes</name>
+            <instance>default</instance>
+        </interface>
+        <interface>
+            <name>IPictureAdjustment</name>
+            <instance>default</instance>
+        </interface>
+    </hal>
+</manifest>


### PR DESCRIPTION
 * The framework manifest must now be split per device, since not
   every interface is supported. In this case, only DisplayModes
   and PictureAdjustment are supported.

Change-Id: Ie2bbb02ab99ae5f4654fd1e459d2919941197040