### PR TITLE
beryllium: Set MIUI 9.2.15 as minimum vendor and firmware requirement

### DIFF
--- a/board-info.txt
+++ b/board-info.txt
@@ -1,3 +1,3 @@
-require version-modem=2018-11-14 19:25:39
-require version-vendor=1542276066,28
-require version-miui=8.11.15
+require version-modem=2019-02-13 23:02:56
+require version-vendor=1550233434,28
+require version-miui=9.2.15


### PR DESCRIPTION
Change-Id: Ifd757c8f3c8e570d39cda0ef39d8d5e83aad6479