### PR TITLE
beryllium: Fix livedisplay modes

### DIFF
--- a/overlay-lineage/lineage-sdk/lineage/res/res/values/config.xml
+++ b/overlay-lineage/lineage-sdk/lineage/res/res/values/config.xml
@@ -69,7 +69,9 @@
          app, they can be remapped here. The format is
          "oldname:newname", one per entry. -->
     <string-array name="config_displayModeMappings" translatable="false">
-        <item>00default:standard</item>
+        <item>OLED_native:standard</item>
+        <item>38oled_native:standard</item>
+        <item>00default:dynamic</item>
         <item>sRGB_d65:srgb</item>
         <item>srgb_d65:srgb</item>
     </string-array>


### PR DESCRIPTION
oled_native is what is default on poco on both panels so remap it to standard
and 00default has bit bright colors so remap it to dynamic

Change-Id: Iec5514674888aac634254278d3b039dd31789039