### PR TITLE
beryllium: Add device specific ACDB loader libraries

### DIFF
--- a/proprietary-files.txt
+++ b/proprietary-files.txt
@@ -9,6 +9,8 @@ vendor/etc/acdbdata/Forte/Forte_Headset_cal.acdb
 vendor/etc/acdbdata/Forte/Forte_Speaker_cal.acdb
 vendor/etc/acdbdata/Forte/Forte_workspaceFile.qwsp
 vendor/etc/acdbdata/adsp_avs_config.acdb
+vendor/lib64/libacdbloader.so
+vendor/lib/libacdbloader.so
 
 # ADSP modules
 vendor/lib/rfsa/adsp/dirac_resource.dar


### PR DESCRIPTION
 * These libs can't be common

Change-Id: I47daba7721e23c6b27bf5b2f077dec4a28cf8cca